### PR TITLE
Generate test coverage when running tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.swp
+coverage/
 logs/*
 !.gitkeep
 node_modules

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "jasmine-core": "^2.3.4",
     "jshint-stylish": "~0.1.3",
     "karma": "^0.12.36",
+    "karma-coverage": "^0.4.2",
     "karma-jasmine": "^0.3.5",
     "karma-phantomjs-launcher": "^0.2.0",
     "load-grunt-tasks": "~0.4.0",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -30,7 +30,13 @@ module.exports = function(config){
 
     browsers : ['PhantomJS'],
 
-    singleRun: true
+    singleRun: true,
+
+    reporters: ['progress', 'coverage'],
+
+    preprocessors: {
+      'app/scripts/**/*.js': ['coverage']
+    }
 
   });
 };


### PR DESCRIPTION
Generates test coverage when running Karma tests. The output goes into `coverage/` and can be viewed by opening the `index.html` file nested in that directory.
