### PR TITLE
Send dates as ISO8601

### DIFF
--- a/app/scripts/controllers/donors.js
+++ b/app/scripts/controllers/donors.js
@@ -436,8 +436,8 @@ angular.module('bsis')
         donation.donorNumber = $scope.donor.donorNumber;
         console.log("$scope.donor.donorNumber: ", $scope.donor.donorNumber);
 
-        donation.bleedStartTime = $filter('date')(bleedStartTime, 'hh:mm:ss a');
-        donation.bleedEndTime = $filter('date')(bleedEndTime, 'hh:mm:ss a');
+        donation.bleedStartTime = bleedStartTime;
+        donation.bleedEndTime = bleedEndTime;
 
         DonorService.addDonation(donation, function(response){
           if (response !== false){
@@ -991,8 +991,8 @@ angular.module('bsis')
         donation.donorPanel = $scope.donationBatch.donorPanel;
         donation.collectedOn = $scope.donationBatch.createdDate;
         donation.collectionBatchNumber = $scope.donationBatch.batchNumber;
-        donation.bleedStartTime = $filter('date')(bleedStartTime, 'hh:mm:ss a');
-        donation.bleedEndTime = $filter('date')(bleedEndTime, 'hh:mm:ss a');
+        donation.bleedStartTime = bleedStartTime;
+        donation.bleedEndTime = bleedEndTime;
 
         DonorService.addDonationToBatch(donation, function(response){
           if (response !== false){


### PR DESCRIPTION
Related to https://github.com/jembi/bsis/pull/311.

Send times as ISO8601 date strings. The bleed times are stored as dates on the server side and the format matches that of the bleed times received from the API.
