### PR TITLE
Clean up code for setting the selected menu item in the header

### DIFF
--- a/app/scripts/controllers/header.js
+++ b/app/scripts/controllers/header.js
@@ -58,198 +58,131 @@ angular.module('bsis')
     }
   ];
 
-  // set menu on initial load
-  // if on donors page, set menu to DONORS
-  if(~$location.path().indexOf('donors')                  ||
-    ~$location.path().indexOf('findDonor')                ||
-    ~$location.path().indexOf('addDonor')                 ||
-    ~$location.path().indexOf('viewDonor')                ||
-    ~$location.path().indexOf('addDonation')              ||
-    ~$location.path().indexOf('manageDonationBatches')    ||
-    ~$location.path().indexOf('manageClinic')             ||
-    ~$location.path().indexOf('exportDonorList')
-    ){
-      $scope.currentSection = 'DONORS';
+  var donorRoutes = [
+    '/donors',
+    '/findDonor',
+    '/addDonor',
+    '/viewDonor',
+    '/addDonation',
+    '/manageDonationBatches',
+    '/manageClinic',
+    '/exportDonorList'
+  ];
 
-    }
+  var componentsRoutes = [
+    '/components',
+    '/findComponents',
+    '/recordComponents',
+    '/findDiscards',
+    '/discardComponents'
+  ];
 
-  // else if on components page, set menu to COMPONENTS
-  else if(~$location.path().indexOf('components')   ||
-      ~$location.path().indexOf('findComponents')   ||
-      ~$location.path().indexOf('recordComponents') ||
-      ~$location.path().indexOf('findDiscards')     ||
-      ~$location.path().indexOf('discardComponents')
-    ){
-      $scope.currentSection = 'COMPONENTS';
-    }
+  var testingRoutes = [
+    '/testing',
+    '/viewTestResults',
+    '/manageTestBatch',
+    '/viewTestBatch',
+    '/manageTTITesting',
+    '/managePendingTests',
+    '/manageBloodGroupTesting',
+    '/manageBloodGroupMatchTesting',
+    '/uploadTestResults'
+  ];
 
-  // else if on testing page, set menu to TESTING
-  else if(~$location.path().indexOf('testing')                   ||
-      ~$location.path().indexOf('viewTestResults')               ||
-      ~$location.path().indexOf('manageTestBatch')               ||
-      ~$location.path().indexOf('viewTestBatch')                 ||
-      ~$location.path().indexOf('manageTTITesting')              ||
-      ~$location.path().indexOf('managePendingTests')            ||
-      ~$location.path().indexOf('manageBloodGroupTesting')       ||
-      ~$location.path().indexOf('manageBloodGroupMatchTesting')  ||
-      ~$location.path().indexOf('uploadTestResults')
-    ){
-      $scope.currentSection = 'TESTING';
-    }
+  var inventoryRoutes = [
+    '/inventory',
+    '/manageInventory',
+    '/transferComponents',
+    '/issueComponents',
+    '/componentUsage'
+  ];
 
-  // else if on inventory page, set menu to INVENTORY
-  else if(~$location.path().indexOf('inventory')        ||
-      ~$location.path().indexOf('manageInventory')      ||
-      ~$location.path().indexOf('transferComponents')   ||
-      ~$location.path().indexOf('issueComponents')      ||
-      ~$location.path().indexOf('componentUsage')
-    ){
-      $scope.currentSection = 'INVENTORY';
-    }
+  var labellingRoutes = [
+    '/labelling',
+    '/labelComponents'
+  ];
 
-  // else if on labelling page, set menu to LABELLING
-  else if(~$location.path().indexOf('labelling')           ||
-      ~$location.path().indexOf('labelComponents')
-    ){
-      $scope.currentSection = 'LABELLING';
-    }
+  var reportsRoutes = [
+    '/reports'
+  ];
 
-  // else if on reports page, set menu to REPORTS
-  else if(~$location.path().indexOf('reports')
-    ){
-      $scope.currentSection = 'REPORTS';
-    }
+  var mobileRoutes = [
+    '/mobile'
+  ];
 
-  // else if on mobile clinic page, set menu to MOBILE
-  else if(~$location.path().indexOf('mobile')
-    ){
-      $scope.currentSection = 'MOBILE';
-    }
+  var settingsRoutes = [
+    '/settings',
+    '/accountSettings',
+    '/locations',
+    '/deferralReasons',
+    '/manageDeferralReason',
+    '/discardReasons',
+    '/manageDiscardReason',
+    '/configurations',
+    '/manageConfiguration',
+    '/users',
+    '/manageUser',
+    '/roles',
+    '/manageRole',
+    '/donationTypes',
+    '/manageDonationType',
+    '/packTypes',
+    '/managePackType'
+  ];
 
-  // else if on settings page, set menu to SETTINGS
-  else if(~$location.path().indexOf('settings')        ||
-      ~$location.path().indexOf('accountSettings')     ||
-      ~$location.path().indexOf('locations')           ||
-      ~$location.path().indexOf('deferralReasons')     ||
-      ~$location.path().indexOf('manageDeferralReason')||
-      ~$location.path().indexOf('discardReasons')      ||
-      ~$location.path().indexOf('manageDiscardReason') ||
-      ~$location.path().indexOf('configurations')      ||
-      ~$location.path().indexOf('manageConfiguration') ||
-      ~$location.path().indexOf('users')               ||
-      ~$location.path().indexOf('manageUser')          ||
-      ~$location.path().indexOf('roles')               ||
-      ~$location.path().indexOf('manageRole')          ||
-      ~$location.path().indexOf('donationTypes')       ||
-      ~$location.path().indexOf('manageDonationType')  ||
-      ~$location.path().indexOf('packTypes')           ||
-      ~$location.path().indexOf('managePackType')
-    ){
-      $scope.currentSection = 'SETTINGS';
-    }
-
-  // else set menu to HOME
-  else{
-      $scope.currentSection = 'HOME';
-    }
-
-  //set menu on location change
-  $scope.$on('$locationChangeStart', function(event){
+  var setMenuSelection = function() {
 
     // if on donors page, set menu to DONORS
-    if(~$location.path().indexOf('donors')                  ||
-      ~$location.path().indexOf('findDonor')                ||
-      ~$location.path().indexOf('addDonor')                 ||
-      ~$location.path().indexOf('viewDonor')                ||
-      ~$location.path().indexOf('addDonation')              ||
-      ~$location.path().indexOf('manageDonationBatches')    ||
-      ~$location.path().indexOf('manageClinic')             ||
-      ~$location.path().indexOf('exportDonorList')
-      ){
-        $scope.currentSection = 'DONORS';
-
-      }
+    if (donorRoutes.indexOf($location.path()) >= 0) {
+      $scope.currentSection = 'DONORS';
+    }
 
     // else if on components page, set menu to COMPONENTS
-    else if(~$location.path().indexOf('components')   ||
-        ~$location.path().indexOf('findComponents')   ||
-        ~$location.path().indexOf('recordComponents') ||
-        ~$location.path().indexOf('findDiscards')     ||
-        ~$location.path().indexOf('discardComponents')
-    ){
+    else if (componentsRoutes.indexOf($location.path()) >= 0) {
       $scope.currentSection = 'COMPONENTS';
     }
 
     // else if on testing page, set menu to TESTING
-    else if(~$location.path().indexOf('testing')                 ||
-      ~$location.path().indexOf('viewTestResults')               ||
-      ~$location.path().indexOf('manageTestBatch')               ||
-      ~$location.path().indexOf('viewTestBatch')                 ||
-      ~$location.path().indexOf('manageTTITesting')              ||
-      ~$location.path().indexOf('managePendingTests')            ||
-      ~$location.path().indexOf('manageBloodGroupTesting')       ||
-      ~$location.path().indexOf('manageBloodGroupMatchTesting')  ||
-      ~$location.path().indexOf('uploadTestResults')
-    ){
+    else if (testingRoutes.indexOf($location.path()) >= 0) {
       $scope.currentSection = 'TESTING';
     }
 
       // else if on inventory page, set menu to INVENTORY
-    else if(~$location.path().indexOf('inventory')        ||
-        ~$location.path().indexOf('manageInventory')      ||
-        ~$location.path().indexOf('transferComponents')   ||
-        ~$location.path().indexOf('issueComponents')      ||
-        ~$location.path().indexOf('componentUsage')
-      ){
-        $scope.currentSection = 'INVENTORY';
-      }
+    else if (inventoryRoutes.indexOf($location.path()) >= 0) {
+      $scope.currentSection = 'INVENTORY';
+    }
 
       // else if on labelling page, set menu to LABELLING
-    else if(~$location.path().indexOf('labelling')           ||
-        ~$location.path().indexOf('labelComponents')
-      ){
-        $scope.currentSection = 'LABELLING';
-      }
+    else if (labellingRoutes.indexOf($location.path()) >= 0) {
+      $scope.currentSection = 'LABELLING';
+    }
 
     // else if on reports page, set menu to REPORTS
-    else if(~$location.path().indexOf('reports')
-      ){
-        $scope.currentSection = 'REPORTS';
-      }
+    else if (reportsRoutes.indexOf($location.path()) >= 0) {
+      $scope.currentSection = 'REPORTS';
+    }
 
     // else if on mobile clinic page, set menu to MOBILE
-    else if(~$location.path().indexOf('mobile')
-      ){
-        $scope.currentSection = 'MOBILE';
-      }
+    else if (mobileRoutes.indexOf($location.path()) >= 0) {
+      $scope.currentSection = 'MOBILE';
+    }
 
     // else if on settings page, set menu to SETTINGS
-    else if(~$location.path().indexOf('settings')      ||
-      ~$location.path().indexOf('accountSettings')     ||
-      ~$location.path().indexOf('locations')           ||
-      ~$location.path().indexOf('deferralReasons')     ||
-      ~$location.path().indexOf('manageDeferralReason')||
-      ~$location.path().indexOf('discardReasons')      ||
-      ~$location.path().indexOf('manageDiscardReason') ||
-      ~$location.path().indexOf('configurations')      ||
-      ~$location.path().indexOf('manageConfigurations')||
-      ~$location.path().indexOf('packTypes')           ||
-      ~$location.path().indexOf('managePackType')      ||
-      ~$location.path().indexOf('donationTypes')       ||
-      ~$location.path().indexOf('manageDonationType')  ||
-      ~$location.path().indexOf('users')               ||
-      ~$location.path().indexOf('manageUser')          ||
-      ~$location.path().indexOf('roles')               ||
-      ~$location.path().indexOf('manageRole')
-      ){
-        $scope.currentSection = 'SETTINGS';
-      }
+    else if (settingsRoutes.indexOf($location.path()) >= 0) {
+      $scope.currentSection = 'SETTINGS';
+    }
 
     // else set menu to HOME
-    else{
+    else {
       $scope.currentSection = 'HOME';
     }
 
+  };
+
+  //set menu on location change
+  var unregisterLocationListener = $scope.$on('$locationChangeStart', setMenuSelection);
+  $scope.$on('$destroy', function() {
+    unregisterLocationListener();
   });
 
   $scope.status = {
@@ -264,7 +197,10 @@ angular.module('bsis')
 
   $scope.logout = function () {
     AuthService.logout();
-    $location.path( "/" );
+    $location.path('/');
   };
+
+  // set menu on initial load
+  setMenuSelection();
 
 });


### PR DESCRIPTION
Match full paths instead of partial matches. This was causing issues in
the case where a route contains a string already matched by another
route e.g. all routes containing 'donors' set the menu to donors even if
this should not be the case.

@danfuterman Please review.
