### PR TITLE
Fix saving donor with no preferred address type

### DIFF
--- a/app/views/donors/viewDonorDemographics.html
+++ b/app/views/donors/viewDonorDemographics.html
@@ -58,7 +58,7 @@
         <td class="icon"><i class="fa {{icons.GLOBE}}"></i></td>
         <td class="field">Preferred Address Type:</td>
         <td class="value">
-          <span e-class="xeditable" editable-select="donor.preferredAddressType.id" e-ng-options="item.id as item.preferredAddressType for item in addressTypes" e-name="preferredAddressType">
+          <span e-class="xeditable" editable-select="donor.preferredAddressType" e-ng-options="item as item.preferredAddressType for item in addressTypes" e-name="preferredAddressType">
             {{donor.preferredAddressType.preferredAddressType}}
           </span>
         </td>


### PR DESCRIPTION
Sending through an empty preferred address type causes a
TransientObjectException on the backend. The preferred address type was
being set to an object with an id property with a value of undefined.
This change leaves the preferred address type set to null unless a valid
address type is selected.
