### PR TITLE
Fix session expiry

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -353,8 +353,7 @@ var app = angular.module('bsis', [
       //check if session exists
       if( consoleSession ){
         //check if session has expired
-        var currentTime = new Date();
-        currentTime = currentTime.toISOString();
+        var currentTime = Date.now();
         if( currentTime >= consoleSession.expires ){
           //session expired - user needs to log in
           AuthService.logout();

--- a/app/scripts/services/auth.js
+++ b/app/scripts/services/auth.js
@@ -34,7 +34,7 @@ angular.module('bsis')
       sessionUser: loggedOnUser.username,
       sessionUserName: fullName,
       sessionUserPermissions: permissions,
-      expires: expiryTime
+      expires: expiryTime.getTime()
     };
 
     $rootScope.displayHeader = true;

--- a/test/spec/services/auth.js
+++ b/test/spec/services/auth.js
@@ -135,7 +135,7 @@ describe('Service: Auth', function() {
       AuthService.refreshSession();
 
       var storedSession = angular.fromJson(localStorage.getItem('consoleSession'));
-      expect(storedSession.expires).toBe(new Date(currentDate.getTime() + (1000 * 60 * 60)).toISOString());
+      expect(storedSession.expires).toBe(new Date(currentDate.getTime() + (1000 * 60 * 60)).getTime());
       expect(storedSession.sessionUser).toBe(mockUser.username);
       expect(storedSession.sessionUserName).toBe(sessionUserName);
       expect(storedSession.sessionUserPermissions).toDeepEqual(sessionUserPermissions);


### PR DESCRIPTION
Compare dates as timestamps instead of strings. Comparing strings doesn't work because they may use different formats.

This fixes the issue that @carlsbox and @jonojhs were experiencing where user sessions were not expiring.

@danfuterman Please review.
