### PR TITLE
Deployment script fixes

### DIFF
--- a/infrastructure/deployment/env/provision.sh
+++ b/infrastructure/deployment/env/provision.sh
@@ -19,8 +19,9 @@ if ! fgrep --silent ".npm-packages" ~/.profile; then
   # Configure the directory for global npm installs
   echo "prefix = ${HOME}/.npm-packages" > ~/.npmrc
   echo "export PATH=\"${HOME}/.npm-packages/bin:\${PATH}\"" >> ~/.profile
-  source ~/.profile
 fi
+
+source ~/.profile
 
 # Install grunt and bower
 npm install --global bower grunt-cli

--- a/infrastructure/development/env/provision.sh
+++ b/infrastructure/development/env/provision.sh
@@ -18,8 +18,9 @@ if ! fgrep --silent ".npm-packages" ~/.profile; then
   # Configure the directory for global npm installs
   echo "prefix = ${HOME}/.npm-packages" > ~/.npmrc
   echo 'export PATH="${HOME}/.npm-packages/bin:${PATH}"' >> ~/.profile
-  source ~/.profile
 fi
+
+source ~/.profile
 
 # Install grunt and bower
 npm install --global bower grunt-cli


### PR DESCRIPTION
Fixes 2 bugs which occur when rerunning the deployment script after a failure:
1. "Not a git repository" error because of a failed clone.
2. "grunt: command not found" because of unset path variable.
