### PR TITLE
saving blood serology outcomes before doing the confirmation

### DIFF
--- a/app/scripts/controllers/testing.js
+++ b/app/scripts/controllers/testing.js
@@ -912,23 +912,24 @@ angular.module('bsis')
         updatedTestResults.testResults = { };
         updatedTestResults.testResults[aboTestId] = value.bloodAbo;
         updatedTestResults.testResults[rhTestId] = value.bloodRh == "+" ? "POS" : "NEG";
-        TestingService.saveTestResults(updatedTestResults, function(response) {
+        var request1 = TestingService.saveTestResults(updatedTestResults, function(response) {
           if (response === true) {
             // save confirmation
             if (value.confirm) {
-              var request = TestingService.saveBloodGroupMatchTestResults(value, function(response){
+              var request2 = TestingService.saveBloodGroupMatchTestResults(value, function(response){
                 if (response === true){
                 }
                 else{
                   // TODO: handle case where response == false
                 }
               });
-              requests.push(request);
+              requests.push(request2);
             }
           } else {
             // TODO: handle case where response == false
           }
         });
+        requests.push(request1);
       });
 
       $q.all(requests).then(function(){


### PR DESCRIPTION
Closes #331

This fix was a little difficult because I was unsure of exactly how we wish to change the serology outcome confirmation in future releases. 

My initial idea was to just disable the editing of serology outcomes during confirmation because the modified blood test results weren't being saved (and the user can still just go back and edit the results on the Record Test Results page). However, although that was a very easy fix, I decided to implement a fix by calling the endpoint to save test results before the existing call to the endpoint that confirms the blood match.

It was a little complicated because I needed to find the ids of the ABO and Rh blood tests - the Abo and Rh results are hardcoded on the page. I had to hardcode the keys "ABO" and "Rh" in order to match the tests and determine the ids. This may not be future proof, but believe it will do until we update the serology confirmation process.
