### PR TITLE
BSIS-578 Always allow ambiguous ABO/Rh outcomes to be resolved

### DIFF
--- a/app/views/testing/manageBloodGroupMatchTesting.html
+++ b/app/views/testing/manageBloodGroupMatchTesting.html
@@ -59,7 +59,7 @@
                     </thead>
                     <tbody>
                     <tr ng-repeat="sample in $data"
-                        ng-show="sample.bloodTypingStatus === 'COMPLETE' && sample.bloodTypingMatchStatus === 'AMBIGUOUS'"
+                        ng-show="sample.bloodTypingMatchStatus === 'AMBIGUOUS'"
                         ng-click=""
                         ng-mouseenter="this.$selected = true"
                         ng-mouseleave="this.$selected = false"


### PR DESCRIPTION
Fixes a bug preventing ambiguous outcomes from being resolved when the
Titre or AbScr tests have not yet been done.
