### PR TITLE
BSIS-740 Make Array.find polyfill non-enumerable

### DIFF
--- a/app/scripts/find.js
+++ b/app/scripts/find.js
@@ -1,25 +1,27 @@
 /* Polyfill for the Array.find function from: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find#Polyfill */
 /* eslint-disable */
 if (!Array.prototype.find) {
-  Array.prototype.find = function(predicate) {
-    if (this === null) {
-      throw new TypeError('Array.prototype.find called on null or undefined');
-    }
-    if (typeof predicate !== 'function') {
-      throw new TypeError('predicate must be a function');
-    }
-    var list = Object(this);
-    var length = list.length >>> 0;
-    var thisArg = arguments[1];
-    var value;
-
-    for (var i = 0; i < length; i++) {
-      value = list[i];
-      if (predicate.call(thisArg, value, i, list)) {
-        return value;
+  Object.defineProperty(Array.prototype, 'find', {
+    value: function(predicate) {
+      if (this === null) {
+        throw new TypeError('Array.prototype.find called on null or undefined');
       }
+      if (typeof predicate !== 'function') {
+        throw new TypeError('predicate must be a function');
+      }
+      var list = Object(this);
+      var length = list.length >>> 0;
+      var thisArg = arguments[1];
+      var value;
+
+      for (var i = 0; i < length; i++) {
+        value = list[i];
+        if (predicate.call(thisArg, value, i, list)) {
+          return value;
+        }
+      }
+      return undefined;
     }
-    return undefined;
-  };
+  });
 }
 /* eslint-enable */


### PR DESCRIPTION
The find polyfill being added to the Array prototype was enumerable
which meant that looping through the array with for..in would receive
the find function as one of the values. This was causing the test to
fail since an extra permission was being added to the permissions array
with the name of the find function. This function is anonymous so the
value being added was an empty string. By defining the find property as
non-enumerable it will not be included when using for..in and therefore
not included in the permissions so the test passes.
