### PR TITLE
BSIS-743 Allow any git ref to be sepcified for provision scripts

### DIFF
--- a/infrastructure/deployment/env/provision.sh
+++ b/infrastructure/deployment/env/provision.sh
@@ -29,10 +29,9 @@ npm install --global bower grunt-cli
 if [ -d "/opt/bsis-frontend/.git" ]; then
   # Checkout the latest version
   cd /opt/bsis-frontend
-  git fetch
-  git checkout ${1:-master}
-  git merge --ff-only origin/${1:-master}
-else 
+  git fetch origin ${1:-master}
+  git checkout FETCH_HEAD
+else
   if ! ssh-add -l; then
     # Fall back to http
     BSIS_REPOSITORY=https://github.com/jembi/bsis-frontend.git

--- a/infrastructure/deployment/env/update.sh
+++ b/infrastructure/deployment/env/update.sh
@@ -5,9 +5,8 @@ set -o nounset
 
 # Checkout the latest version
 cd /opt/bsis-frontend
-git fetch
-git checkout ${1:-master}
-git merge --ff-only origin/${1:-master}
+git fetch origin ${1:-master}
+git checkout FETCH_HEAD
 
 # Install dependencies
 npm install


### PR DESCRIPTION
Fetch the specific reference and check it out instead of fetching all
refs and merging changes into the local version.
