### PR TITLE
Donor view test outcomes permissions

### DIFF
--- a/app/scripts/controllers/donors/donorCounsellingDetails.js
+++ b/app/scripts/controllers/donors/donorCounsellingDetails.js
@@ -1,7 +1,8 @@
 'use strict';
 
-angular.module('bsis').controller('DonorCounsellingDetailsCtrl', function($scope, $window, $routeParams, $log, DonorService, PostDonationCounsellingService, TestingService) {
+angular.module('bsis').controller('DonorCounsellingDetailsCtrl', function($scope, $window, $routeParams, $log, DonorService, PostDonationCounsellingService, TestingService, PERMISSIONS) {
 
+  $scope.permissions = PERMISSIONS;
   $scope.postDonationCounselling = {};
   $scope.donation = {};
   $scope.donor = {};

--- a/app/views/donors/donationDetails.html
+++ b/app/views/donors/donationDetails.html
@@ -70,7 +70,8 @@
         </table>
     </div>
 
-    <div class="col-sm-7" style="height:100%; " ng-show="donation.packType.testSampleProduced">
+    <div has-permission="{{permissions.VIEW_TEST_OUTCOME}}"
+    class="col-sm-7" style="height:100%; " ng-show="donation.packType.testSampleProduced">
 
 
     <span>

--- a/app/views/donors/viewDonationSummary.html
+++ b/app/views/donors/viewDonationSummary.html
@@ -226,7 +226,7 @@
             </table>
         </div>
         <table class="pull-right">
-            <tr has-permission="{{permissions.VIEW_POST_DONATION_COUNSELLING_DONORS}}">
+            <tr has-permission="{{permissions.VIEW_TEST_OUTCOME}}">
                 <td ng-if="showTestResults" class="value"><em class="pull-right" style="padding:0 15px;">
                     <a style="cursor: pointer;" ng-click="toggleShowResults(false)">Hide test outcomes</a>
                 </em>


### PR DESCRIPTION
Testing with donorclinicsupervisor, who has permission to view counselling details, but not test outcomes.
Note: this role should probably be assigned the 'View Test Outcome' permission in any case, but I think the permission updates in this PR are more consistent/relevant to the affected sections.

For https://github.com/jembi/bsis-frontend/commit/6834aed247792441e771bdf0db3558795754f903:

Before - it would show the Test Outcomes section, but would not display any of the actual outcomes:
![image](https://cloud.githubusercontent.com/assets/1052668/15466661/04e80692-20db-11e6-896e-e7fc04ef029a.png)

After - Use the permission VIEW_TEST_OUTCOME to hide the toggle link to Show/Hide Test Outcomes:

![image](https://cloud.githubusercontent.com/assets/1052668/15466687/24d22ca8-20db-11e6-86ec-731d1ef10d36.png)

For https://github.com/jembi/bsis-frontend/commit/b268e29be29222fa84ca515f37d57215131bbc33:

Similarly, before it would show the Test Outcomes section, but would not display any of the actual outcomes:
![image](https://cloud.githubusercontent.com/assets/1052668/15466779/837502da-20db-11e6-9e3e-5d9e81cdad7a.png)

After - Use the permission VIEW_TEST_OUTCOME to hide the section:
![image](https://cloud.githubusercontent.com/assets/1052668/15466796/9175cd4c-20db-11e6-947d-d87de8e9d7cb.png)
